### PR TITLE
[Internal Review] Add per-host configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+aws-sigv4-proxy

--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,5 @@ require (
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
+	gopkg.in/yaml.v2 v2.3.0
 )

--- a/handler/config_set.go
+++ b/handler/config_set.go
@@ -1,0 +1,10 @@
+package handler
+
+// ConfigSet contains overrides for individual hosts
+type ConfigSet struct {
+	Name string
+	Region string
+	Host string
+	RoleArn string `yaml:"role-arn"`
+}
+

--- a/handler/config_set.go
+++ b/handler/config_set.go
@@ -2,9 +2,9 @@ package handler
 
 // ConfigSet contains overrides for individual hosts
 type ConfigSet struct {
-	Name string
-	Region string
-	Host string
+	Name string    `yaml:"name"`
+	Region string  `yaml:"region"`
+	Host string    `yaml:"host"`
 	RoleArn string `yaml:"role-arn"`
 }
 

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -34,7 +34,10 @@ func (h *Handler) write(w http.ResponseWriter, status int, body []byte) {
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	client := h.ProxyClients["default"]
+	client, ok := h.ProxyClients["default"]
+	if !ok {
+		log.Fatal("Default client does not exist, this configuration is not supported")
+	}
 
 	if val, ok := h.ProxyClients[r.Host]; ok {
 		client = val

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -25,7 +25,7 @@ import (
 )
 
 type Handler struct {
-	ProxyClient Client
+	ProxyClients map[string]Client
 }
 
 func (h *Handler) write(w http.ResponseWriter, status int, body []byte) {
@@ -34,7 +34,13 @@ func (h *Handler) write(w http.ResponseWriter, status int, body []byte) {
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	resp, err := h.ProxyClient.Do(r)
+	client := h.ProxyClients["default"]
+
+	if val, ok := h.ProxyClients[r.Host]; ok {
+		client = val
+	}
+
+	resp, err := client.Do(r)
 	if err != nil {
 	    errorMsg := "unable to proxy request"
 		log.WithError(err).Error(errorMsg)

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -54,7 +54,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		{
 			name: "responds with 502 if proxy request fails",
 			handler: &Handler{
-				ProxyClient: &mockProxyClient{Fail: true},
+				ProxyClients: map[string]Client{"default": &mockProxyClient{Fail: true}},
 			},
 			request: &http.Request{},
 			want: &want{
@@ -66,12 +66,14 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		{
 			name: "responds with proxied response if everything is 👍",
 			handler: &Handler{
-				ProxyClient: &mockProxyClient{
-					Response: &http.Response{
-						Header: http.Header{
-							"test": []string{"header"},
+				ProxyClients: map[string]Client{
+					"default": &mockProxyClient{
+						Response: &http.Response{
+							Header: http.Header{
+								"test": []string{"header"},
+							},
+							Body: ioutil.NopCloser(bytes.NewBuffer([]byte(`proxy call successful`))),
 						},
-						Body: ioutil.NopCloser(bytes.NewBuffer([]byte(`proxy call successful`))),
 					},
 				},
 			},

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -86,6 +86,30 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				body: []byte(`proxy call successful`),
 			},
 		},
+		{
+			name: "uses host config-set if a match is found",
+			handler: &Handler{
+				ProxyClients: map[string]Client{
+					"default":  &mockProxyClient{Fail: true},
+					"example.com": &mockProxyClient{
+						Response: &http.Response{
+							Header: http.Header{
+								"test": []string{"this came from the target host"},
+							},
+							Body: ioutil.NopCloser(bytes.NewBuffer([]byte(`proxy call successful`))),
+						},
+					},
+				},
+			},
+			request: &http.Request{Host: "example.com"},
+			want: &want{
+				statusCode: http.StatusOK,
+				header: http.Header{
+					"Test": []string{"this came from the target host"},
+				},
+				body: []byte(`proxy call successful`),
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Notice**
> This PR is for internal review
> Once we've checked it over, we'll take the branch and initiate a PR into the upstream repo if we feel it is relevant

---

# Per Host Configs

This PR introduces a new repeatable flag to the CLI called `--config-set`. A config-set is a per-host configuration of the override values for the proxy, namely:
- name (which aws service to invoke, for example `execute-api`)
- host
- role-arn
- region

Using these flags, you can configure the proxy to use a different configuration based on which host is being requested. For example:

```
./aws-sigv4-proxy \
    --config-set '{name: execute-api, host: x.myapi.com, region: eu-west-1, role-arn: arn:aws:iam::123:role/invoke-myapi-role}' \
    --config-set '{name: execute-api, host: x.otherapi.com, region: ap-southeast-1, role-arn: arn:aws:iam::456:role/invoke-otherapi-role}' 
```

If the domain does not match any of the config sets, the proxy will default to its original (existing) behaviour.

![image](https://user-images.githubusercontent.com/16408267/106113454-7833b300-6189-11eb-83b2-15b9b8376b48.png)
